### PR TITLE
feat: update winio to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oneshot"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
+
+[[package]]
 name = "os_pipe"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2501,12 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -3434,9 +3446,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winio"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370858ee776a5044aff42a378a8608fd8b82ab5faffc9e81fa5618ebed3e8538"
+checksum = "2225df0979ee5401872e2c0c51fa8b00c1dd093fa53a0013653f514736689a6a"
 dependencies = [
  "cfg-if",
  "compio",
@@ -3452,6 +3464,7 @@ dependencies = [
  "winio-ui-gtk",
  "winio-ui-qt",
  "winio-ui-win32",
+ "winio-ui-winui",
 ]
 
 [[package]]
@@ -3477,15 +3490,16 @@ dependencies = [
 
 [[package]]
 name = "winio-handle"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b442ee90eb0e4c74ca3beecfee08a7e09bce2bd80076958162f799ea26bba0"
+checksum = "f7337217259ea07f4f53fb45ba370902db9a6f625e34a9ee7cbca5250b68adba"
 dependencies = [
  "cfg-if",
  "gtk4",
  "objc2",
  "objc2-app-kit",
  "windows-sys 0.60.2",
+ "winio-winui3",
 ]
 
 [[package]]
@@ -3522,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "winio-ui-app-kit"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad699c5b48ffb636418924cce1827399ae137fae6868b69d58994bc02bb0e32"
+checksum = "db0a9fbd4e5c9a933a19523b4de7666ff7b02c49d2378e504b4bb80df62b33c1"
 dependencies = [
  "block2",
  "compio",
@@ -3548,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "winio-ui-gtk"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0230562c8a08f7498e9dd585021c5edeb33a5e51d5499fb859e3c0b348242ba"
+checksum = "c61c36e2923a68d6a4634efe93ed3b70aca3c7c2e002fc142eff7fde08e3e0fb"
 dependencies = [
  "gtk4",
  "image",
@@ -3584,19 +3598,36 @@ dependencies = [
 
 [[package]]
 name = "winio-ui-win32"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aae222b5574169567b2cb42ba338ef7d02d3fc8804c1d5db66f2cdf03c669c1"
+checksum = "c749caa22b221d853200fa4d19e256e4d63a43aebbed78e3ad2fbc9e02493663"
 dependencies = [
- "cfg-if",
  "compio",
  "compio-log",
- "embed-resource",
  "futures-util",
  "image",
  "inherit-methods-macro",
  "scoped-tls",
  "slab",
+ "widestring",
+ "windows",
+ "windows-sys 0.60.2",
+ "winio-handle",
+ "winio-pollable",
+ "winio-primitive",
+ "winio-ui-windows-common",
+]
+
+[[package]]
+name = "winio-ui-windows-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b983f5b7782b40814ce07eed97bf15703226720a06bb0a7aa1b9b5390e1aaf"
+dependencies = [
+ "cfg-if",
+ "compio",
+ "embed-resource",
+ "image",
  "slim-detours-sys",
  "sync-unsafe-cell",
  "widestring",
@@ -3604,8 +3635,44 @@ dependencies = [
  "windows-numerics",
  "windows-sys 0.60.2",
  "winio-handle",
- "winio-pollable",
  "winio-primitive",
+]
+
+[[package]]
+name = "winio-ui-winui"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad9947c2c23cfb15b8baf50fe3030f14461ef04e80f69153ac1f5f2ec46e305"
+dependencies = [
+ "compio",
+ "compio-log",
+ "compio-runtime",
+ "image",
+ "inherit-methods-macro",
+ "oneshot",
+ "scoped-tls",
+ "send_wrapper",
+ "widestring",
+ "windows",
+ "windows-sys 0.60.2",
+ "winio-callback",
+ "winio-handle",
+ "winio-primitive",
+ "winio-ui-windows-common",
+ "winio-winui3",
+]
+
+[[package]]
+name = "winio-winui3"
+version = "0.1.0+winui3-1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3248e9f1affed8ea66784745dd08ed5bcaa7b05f8b0ea7168047b6a7529c781"
+dependencies = [
+ "windows",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cairo-rs"
-version = "0.20.12"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e3bd0f4e25afa9cabc157908d14eeef9067d6448c49414d17b3fb55f0eadd0"
+checksum = "f6466a563dea2e99f59f6ffbb749fd0bdf75764f5e6e93976b5e7bd73c4c9efb"
 dependencies = [
  "bitflags",
  "cairo-sys-rs",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059cc746549898cbfd9a47754288e5a958756650ef4652bbb6c5f71a6bda4f8b"
+checksum = "cab7e9f13c802625aad1ad2b4ae3989f4ce9339ff388f335a6f109f9338705e2"
 dependencies = [
  "glib-sys",
  "libc",
@@ -966,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd242894c084f4beed508a56952750bce3e96e85eb68fdc153637daa163e10c"
+checksum = "688dc7eaf551dbac1f5b11d000d089c3db29feb25562455f47c1a2080cc60bda"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
@@ -978,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b34f3b580c988bd217e9543a2de59823fafae369d1a055555e5f95a8b130b96"
+checksum = "5af1823d3d1cb72616873ba0a593bd440eb92da700fdfb047505a21ee3ec3e10"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60"
+checksum = "0a67b064d2f35e649232455c7724f56f977555d2608c43300eabc530eaa4e359"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
@@ -1006,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a"
+checksum = "2edbda0d879eb85317bdb49a3da591ed70a804a10776e358ef416be38c6db2c5"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -1075,9 +1075,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gio"
-version = "0.20.12"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e27e276e7b6b8d50f6376ee7769a71133e80d093bdc363bd0af71664228b831"
+checksum = "273d64c833fbbf7cd86c4cdced893c5d3f2f5d6aeb30fd0c30d172456ce8be2e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1092,22 +1092,22 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83"
+checksum = "2c8130f5810a839d74afc3a929c34a700bf194972bb034f2ecfe639682dd13cc"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "glib"
-version = "0.20.12"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683"
+checksum = "690e8bcf8a819b5911d6ae79879226191d01253a4f602748072603defd5b9553"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.20.12"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145"
+checksum = "e772291ebea14c28eb11bb75741f62f4a4894f25e60ce80100797b6b010ef0f9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215"
+checksum = "4b2be4c74454fb4a6bd3328320737d0fa3d6939e2d570f5d846da00cb222f6a0"
 dependencies = [
  "libc",
  "system-deps",
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda"
+checksum = "ab318a786f9abd49d388013b9161fa0ef8218ea6118ee7111c95e62186f7d31f"
 dependencies = [
  "glib-sys",
  "libc",
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b86dfad7d14251c9acaf1de63bc8754b7e3b4e5b16777b6f5a748208fe9519b"
+checksum = "0487f78e8a772ec89020458fbabadd1332bc1e3236ca1c63ef1d61afd4e5f2cc"
 dependencies = [
  "glib",
  "graphene-sys",
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-sys"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df583a85ba2d5e15e1797e40d666057b28bc2f60a67c9c24145e6db2cc3861ea"
+checksum = "270cefb6b270fcb2ef9708c3a35c0e25c2e831dac28d75c4f87e5ad3540c9543"
 dependencies = [
  "glib-sys",
  "libc",
@@ -1189,9 +1189,9 @@ checksum = "71b01d27060ad58be4663b9e4ac9e2d4806918e8876af8912afbddd1a91d5eaa"
 
 [[package]]
 name = "gsk4"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855"
+checksum = "d5dbe33ceed6fc20def67c03d36e532f5a4a569ae437ae015a7146094f31e10c"
 dependencies = [
  "cairo-rs",
  "gdk4",
@@ -1204,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc"
+checksum = "8d76011d55dd19fde16ffdedee08877ae6ec942818cfa7bc08a91259bc0b9fc9"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -1220,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.9.7"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f274dd0102c21c47bbfa8ebcb92d0464fab794a22fad6c3f3d5f165139a326d6"
+checksum = "938d68ad43080ad5ee710c30d467c1bc022ee5947856f593855691d726305b3e"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.9.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999"
+checksum = "0912d2068695633002b92c5966edc108b2e4f54b58c509d1eeddd4cbceb7315c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6"
+checksum = "a923bdcf00e46723801162de24432cbce38a6810e0178a2d0b6dd4ecc26a1c74"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -2017,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "pango"
-version = "0.20.12"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6576b311f6df659397043a5fa8a021da8f72e34af180b44f7d57348de691ab5c"
+checksum = "2d4803f086c4f49163c31ac14db162112a22401c116435080e4be8678c507d61"
 dependencies = [
  "gio",
  "glib",
@@ -2029,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186909673fc09be354555c302c0b3dcf753cd9fa08dcb8077fa663c80fb243fa"
+checksum = "66872b3cfd328ad6d1a4f89ebd5357119bd4c592a4ddbb8f6bc2386f8ce7b898"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -2041,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "pangocairo"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58890dc451db9964ac2d8874f903a4370a4b3932aa5281ff0c8d9810937ad84f"
+checksum = "dbd3cbd828068961d396de731fd60bbed51dcd2deea704c612b2a589587aa188"
 dependencies = [
  "cairo-rs",
  "glib",
@@ -2054,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "pangocairo-sys"
-version = "0.20.10"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9952903f88aa93e2927e7bca2d1ebae64fc26545a9280b4ce6bddeda26b5c42"
+checksum = "d612b47ee72aaceda8e37afee371a05a4de1259b48622bce4656a5f7f51e37af"
 dependencies = [
  "cairo-sys-rs",
  "glib-sys",
@@ -3446,9 +3446,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winio"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2225df0979ee5401872e2c0c51fa8b00c1dd093fa53a0013653f514736689a6a"
+checksum = "9b3a7060fff5814629e06972ad49c3c13f10c036e0de20d954383deab3a3d012"
 dependencies = [
  "cfg-if",
  "compio",
@@ -3475,9 +3475,9 @@ checksum = "f4e1d71e5e7fe651ed7ef6909dcaef026c9f9397f66b661a7a5122ed2a8944cd"
 
 [[package]]
 name = "winio-elm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547ace27bbb326a8aa830664ee1064e419578899ae90dead162e62305b7ad9ac"
+checksum = "142a4c88e0b51da15318b1e45512f83d0615419f1baacc44af2bef5765a3bb06"
 dependencies = [
  "futures-util",
  "inherit-methods-macro",
@@ -3490,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "winio-handle"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7337217259ea07f4f53fb45ba370902db9a6f625e34a9ee7cbca5250b68adba"
+checksum = "870b1f73c9107d31e30390284c2367e9d8995ccd64e5370e125f7c14d1db4f44"
 dependencies = [
  "cfg-if",
  "gtk4",
@@ -3536,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "winio-ui-app-kit"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0a9fbd4e5c9a933a19523b4de7666ff7b02c49d2378e504b4bb80df62b33c1"
+checksum = "3305ebff66a7e6304831eac1603298e0c175a52a655fd750edd003efdc961e82"
 dependencies = [
  "block2",
  "compio",
@@ -3562,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "winio-ui-gtk"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61c36e2923a68d6a4634efe93ed3b70aca3c7c2e002fc142eff7fde08e3e0fb"
+checksum = "f532a41dafe6721986f1afbe25262672a8c0ad131a91f158b26cae19ce78a91b"
 dependencies = [
  "gtk4",
  "image",
@@ -3579,9 +3579,9 @@ dependencies = [
 
 [[package]]
 name = "winio-ui-qt"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74582c5f05207c48ceb2c8b161f078d6d29968f4202567a0f0c2dc087f69f20d"
+checksum = "025d21e81b635c1e1d89d953544d57a4743c4a5b03d0894f8351649a873136e7"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -3598,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "winio-ui-win32"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c749caa22b221d853200fa4d19e256e4d63a43aebbed78e3ad2fbc9e02493663"
+checksum = "16724f4799cf38cfaa3b7cf6195993f99e1fda7292a9e54da6c8553e218d9a43"
 dependencies = [
  "compio",
  "compio-log",
@@ -3620,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "winio-ui-windows-common"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b983f5b7782b40814ce07eed97bf15703226720a06bb0a7aa1b9b5390e1aaf"
+checksum = "56f606f8dc2756eb38fc880b31d84d74a9b05ba90c14e03194f0b6832c6b0242"
 dependencies = [
  "cfg-if",
  "compio",
@@ -3640,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "winio-ui-winui"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad9947c2c23cfb15b8baf50fe3030f14461ef04e80f69153ac1f5f2ec46e305"
+checksum = "f9fffd2531571ebf0b1758e9c7eb75b764e62c340c8360ab1309fc4f6d04fe72"
 dependencies = [
  "compio",
  "compio-log",
@@ -3664,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "winio-winui3"
-version = "0.1.0+winui3-1.7"
+version = "0.1.1+winui3-1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3248e9f1affed8ea66784745dd08ed5bcaa7b05f8b0ea7168047b6a7529c781"
+checksum = "45aa9e6c8596f2dedfaaae2acde1bc10d40faf8a8ff48452c520962b6a185a30"
 dependencies = [
  "windows",
  "windows-collections",

--- a/fitgirl-ddl-gui/Cargo.toml
+++ b/fitgirl-ddl-gui/Cargo.toml
@@ -16,7 +16,7 @@ futures-util = { workspace = true }
 itertools = { workspace = true }
 spdlog-rs = { workspace = true }
 
-winio = { version = "0.7.0", default-features = false }
+winio = { version = "0.7.2", default-features = false }
 ahash = "0.8.12"
 
 serde = { version = "1.0.219", features = ["derive"] }

--- a/fitgirl-ddl-gui/Cargo.toml
+++ b/fitgirl-ddl-gui/Cargo.toml
@@ -23,8 +23,10 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 
 [features]
-default = ["gtk", "dark-mode"]
+default = ["gtk", "win32", "dark-mode"]
 gtk = ["winio/gtk"]
 qt = ["winio/qt"]
+win32 = ["winio/win32"]
+winui = ["winio/winui"]
 
 dark-mode = ["winio/win32-dark-mode"]


### PR DESCRIPTION
`winio` 0.7.1 adds WinUI3 support, but it's not set as default.